### PR TITLE
Fix logic to track modified file count

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,9 +94,7 @@ readFile(path.join(__dirname, 'android/app/src/main/res/values/strings.xml'))
 
         if (!pattern.test(newName)) {
           return console.log(
-            `"${
-              newName
-            }" is not a valid name for a project. Please use a valid identifier name (alphanumeric and space).`
+            `"${newName}" is not a valid name for a project. Please use a valid identifier name (alphanumeric and space).`
           );
         }
 
@@ -142,23 +140,23 @@ readFile(path.join(__dirname, 'android/app/src/main/res/values/strings.xml'))
         const resolveFilesToModifyContent = () =>
           new Promise(resolve => {
             let filePathsCount = 0;
+            let itemsProcessed = 0;
             listOfFilesToModifyContent.map(file => {
-              filePathsCount += file.paths.length - 1;
+              filePathsCount += file.paths.length;
 
               file.paths.map((filePath, index) => {
-                let itemsProcessed = 0;
                 const newPaths = [];
 
-                if (fs.existsSync(path.join(__dirname, filePath))) {
-                  newPaths.push(path.join(__dirname, filePath));
-                  setTimeout(() => {
-                    itemsProcessed += index;
+                setTimeout(() => {
+                  itemsProcessed++;
+                  if (fs.existsSync(path.join(__dirname, filePath))) {
+                    newPaths.push(path.join(__dirname, filePath));
                     replaceContent(file.regex, file.replacement, newPaths);
-                    if (itemsProcessed === filePathsCount) {
-                      resolve();
-                    }
-                  }, 200 * index);
-                }
+                  }
+                  if (itemsProcessed === filePathsCount) {
+                    resolve();
+                  }
+                }, 200 * index);
               });
             });
           });
@@ -229,28 +227,33 @@ readFile(path.join(__dirname, 'android/app/src/main/res/values/strings.xml'))
             let filePathsCount = 0;
             const { currentBundleID, newBundleID, newBundlePath, javaFileBase } = params;
 
-            bundleIdentifiers(currentAppName, newName, projectName, currentBundleID, newBundleID, newBundlePath).map(
-              file => {
-                filePathsCount += file.paths.length - 1;
-                let itemsProcessed = 0;
+            bundleIdentifiers(
+              currentAppName,
+              newName,
+              projectName,
+              currentBundleID,
+              newBundleID,
+              newBundlePath
+            ).map(file => {
+              filePathsCount += file.paths.length - 1;
+              let itemsProcessed = 0;
 
-                file.paths.map((filePath, index) => {
-                  const newPaths = [];
-                  if (fs.existsSync(path.join(__dirname, filePath))) {
-                    newPaths.push(path.join(__dirname, filePath));
+              file.paths.map((filePath, index) => {
+                const newPaths = [];
+                if (fs.existsSync(path.join(__dirname, filePath))) {
+                  newPaths.push(path.join(__dirname, filePath));
 
-                    setTimeout(() => {
-                      itemsProcessed += index;
-                      replaceContent(file.regex, file.replacement, newPaths);
-                      if (itemsProcessed === filePathsCount) {
-                        const oldBundleNameDir = path.join(__dirname, javaFileBase, currentBundleID);
-                        resolve(oldBundleNameDir);
-                      }
-                    }, 200 * index);
-                  }
-                });
-              }
-            );
+                  setTimeout(() => {
+                    itemsProcessed += index;
+                    replaceContent(file.regex, file.replacement, newPaths);
+                    if (itemsProcessed === filePathsCount) {
+                      const oldBundleNameDir = path.join(__dirname, javaFileBase, currentBundleID);
+                      resolve(oldBundleNameDir);
+                    }
+                  }, 200 * index);
+                }
+              });
+            });
           });
 
         const rename = () => {


### PR DESCRIPTION
The current logic seems to have two issues:

* If a file is not found, the processed count is not increased. I think that this should simply be ignored.
* List of files resolution logic is based on the _index_ of _one_ of the path groups. Instead it should be based on the _count_ of _all_ of the path groups.

This pull request addresses these issues.