### PR TITLE
Checks on name and package name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ readFile(path.join(__dirname, 'android/app/src/main/res/values/strings.xml'))
             );
         }
 
-        if (!pattern.test(newName)) {
+        if (!bundleID && !pattern.test(newName)) {
           return console.log(
             `"${newName}" is not a valid name for a project. Please use a valid identifier name (alphanumeric and space).`
           );


### PR DESCRIPTION
Check app name only if package name is not provided.
App name should contains every character.