### PR TITLE
Fix moving Android Java directory instead of files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -196,7 +196,7 @@ readFile(path.join(__dirname, 'android/app/src/main/res/values/strings.xml'))
                   console.log(successMsg);
                 } else if (move.code === 128) {
                   // if "outside repository" error occured
-                  if (shell.mv('-f', fullCurrentBundlePath, fullNewBundlePath).code === 0) {
+                  if (shell.mv('-f', fullCurrentBundlePath + '/*', fullNewBundlePath).code === 0) {
                     console.log(successMsg);
                   } else {
                     console.log(`Error moving: "${currentJavaPath}" "${newBundlePath}"`);


### PR DESCRIPTION
When the Android Java directory is not versioned, the move functionality was not implemented correctly.

Instead of copying content of `android/app/src/main/java/<old_bundleid>`, it would move the whole directory into the new one. For instance, having `old_bundleid = old.bundle` and `new_bundleid = new.bundle`, the directory
```
java/
  old/
    bundle/
      MainActivity.java
      MainApplication.java
```
would be moved to
```
java/
  new/
    bundle/
      old/
        bundle/
          MainActivity.java
          MainApplication.java
```
instead of
```
java/
  new/
    bundle/
      MainActivity.java
      MainApplication.java
```

This pull request fixes this behaviour.

__N.B.: This happens only if the React Native project is not versioned.__