### PR TITLE
Validate bundleID to match requirements for Android.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,10 +91,15 @@ readFile(path.join(__dirname, 'android/app/src/main/res/values/strings.xml'))
         if (bundleID) {
           newBundlePath = bundleID.replace(/\./g, '/');
           const id = bundleID.split('.');
-          if (id.length < 2)
+          const validBundleID = /^([a-zA-Z]([a-zA-Z0-9_])*\.)+[a-zA-Z]([a-zA-Z0-9_])*$/u;
+          if (id.length < 2) {
             return console.log(
               'Invalid Bundle Identifier. Add something like "com.travelapp" or "com.junedomingo.travelapp"'
             );
+          }
+          if (!validBundleID.test(bundleID)) {
+            return console.log('Invalid Bundle Identifier. It must have at least two segments (one or more dots). Each segment must start with a letter. All characters must be alphanumeric or an underscore [a-zA-Z0-9_]')
+          }
         }
 
         if (!pattern.test(newName)) {


### PR DESCRIPTION
Using this library I renamed my app and changed bundleID to `com.example.mobile-app`. This bundleID works for iOS but not for Android.

Check Android [applicationId](https://developer.android.com/studio/build/application-id) for more details