### PR TITLE
fix(naming): #64 and #43-- only replace the last match of the ios path, this solve the problem when

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "node-replace": "^0.3.3",
+    "replace-last": "^1.2.6",
     "shelljs": "^0.7.7"
   },
   "babel": {

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import replace from 'node-replace';
 import shell from 'shelljs';
 import pjson from '../package.json';
 import path from 'path';
+import replaceLast from 'replace-last';
 import { foldersAndFiles } from './config/foldersAndFiles';
 import { filesToModifyContent } from './config/filesToModifyContent';
 import { bundleIdentifiers } from './config/bundleIdentifiers';
@@ -110,7 +111,7 @@ readFile(path.join(__dirname, 'android/app/src/main/res/values/strings.xml'))
         // Move files and folders from ./config/foldersAndFiles.js
         const resolveFoldersAndFiles = new Promise(resolve => {
           listOfFoldersAndFiles.forEach((element, index) => {
-            const dest = element.replace(new RegExp(nS_CurrentAppName, 'i'), nS_NewName);
+            const dest = replaceLast(element, new RegExp(nS_CurrentAppName, 'i'), nS_NewName);
             let itemsProcessed = 1;
             const successMsg = `/${dest} ${colors.green('RENAMED')}`;
 


### PR DESCRIPTION
old and new name is similar. e.g. if old name is ABC, new name is ABCD, when `element` here is
`ios/ABCD.xcodeproj/xcshareddata/xcschemes/ABC.xcscheme`, the `element.replace()` here will let `dest` be
`ios/ABCDD.xcodeproj/xcshareddata/xcschemes/ABC.xcscheme`, then everything is wrong, because we need
`ios/ABCD.xcodeproj/xcshareddata/xcschemes/ABCD.xcscheme` to be the "dest" instead!
So we need `replaceLast()` to do the right thing.