### PR TITLE
feat: allow special characters (like &, -, −, etc.)

### DIFF
--- a/src/config/bundleIdentifiers.js
+++ b/src/config/bundleIdentifiers.js
@@ -1,10 +1,11 @@
 // nS - No Space
 // lC - Lowercase
-import globby from "globby";
+import globby from 'globby';
+import { clearAppName } from '../utils';
 
 export function bundleIdentifiers({ currentAppName, newName, currentBundleID, newBundleID, newBundlePath }) {
-  const nS_CurrentAppName = currentAppName.replace(/\s/g, '');
-  const nS_NewName = newName.replace(/\s/g, '');
+  const nS_CurrentAppName = clearAppName(currentAppName);
+  const nS_NewName = clearAppName(newName);
 
   return [
     {
@@ -15,7 +16,7 @@ export function bundleIdentifiers({ currentAppName, newName, currentBundleID, ne
     {
       regex: currentBundleID,
       replacement: newBundleID,
-      paths: globby.sync([`${newBundlePath}/**/*.java`])
+      paths: globby.sync([`${newBundlePath}/**/*.java`]),
     },
     {
       // App name (probably) doesn't start with `.`, but the bundle ID will

--- a/src/config/filesToModifyContent.js
+++ b/src/config/filesToModifyContent.js
@@ -1,14 +1,16 @@
 // nS - No Space
 // lC - Lowercase
 
+import { clearAppName, escapeEntities } from '../utils';
+
 export function filesToModifyContent(currentAppName, newName) {
-  const nS_CurrentAppName = currentAppName.replace(/\s/g, '');
-  const nS_NewName = newName.replace(/\s/g, '');
+  const nS_CurrentAppName = clearAppName(currentAppName);
+  const nS_NewName = clearAppName(newName);
 
   return [
     {
       regex: `<string name="app_name">${currentAppName}</string>`,
-      replacement: `<string name="app_name">${newName}</string>`,
+      replacement: `<string name="app_name">${escapeEntities(newName)}</string>`,
       paths: ['android/app/src/main/res/values/strings.xml'],
     },
     {
@@ -37,12 +39,12 @@ export function filesToModifyContent(currentAppName, newName) {
     },
     {
       regex: currentAppName,
-      replacement: newName,
+      replacement: escapeEntities(newName),
       paths: [`ios/${nS_NewName}/Info.plist`],
     },
     {
       regex: `"name": "${nS_CurrentAppName}"`,
-      replacement: `"name": "${nS_NewName}"`,
+      replacement: `"name": "${nS_NewName.toLowerCase()}"`,
       paths: ['package.json'],
     },
     {

--- a/src/config/foldersAndFiles.js
+++ b/src/config/foldersAndFiles.js
@@ -1,9 +1,11 @@
 // nS - No Space
 // lC - Lowercase
 
+import { clearAppName } from '../utils';
+
 export function foldersAndFiles(currentAppName, newName) {
-  const nS_CurrentAppName = currentAppName.replace(/\s/g, '');
-  const nS_NewName = newName.replace(/\s/g, '');
+  const nS_CurrentAppName = clearAppName(currentAppName);
+  const nS_NewName = clearAppName(newName);
 
   return [
     `ios/${nS_CurrentAppName}`,

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,4 +16,18 @@ function readFile(filePath) {
 
 export const loadAppConfig = () => readFile(path.join(__dirname, 'app.json')).then(data => JSON.parse(data));
 
-export const loadAndroidManifest = () => readFile(path.join(__dirname, 'android/app/src/main/AndroidManifest.xml')).then(data => cheerio.load(data));
+export const loadAndroidManifest = () =>
+  readFile(path.join(__dirname, 'android/app/src/main/AndroidManifest.xml')).then(data => cheerio.load(data));
+
+export const clearAppName = name => name.replace(/[^\p{Letter}\p{Number}]/gu, '');
+
+const entities = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+};
+
+export const escapeEntities = name => name.replace(/[&<>]/g, tag => entities[tag]);
+
+// https://developer.apple.com/app-store/product-page/
+export const isValidAppStoreName = name => name.length > 0 && name.length <= 30;


### PR DESCRIPTION
App name can consists of many characters that don't fit into `\p{Letter}` regexp. For example, the app I currently working on contains `&`. Like `m&ms`. Also different type of hyphens are also popular.

1. `clearAppName` clears the name from any non-alphanumeric characters for usage in paths and as identifiers.
2. `escapeEntities` escapes `&<>` in names for usage in XML files
3. `isValidAppStoreName` is a draft for checking if an app name fits into AppStore rules
4. `--force` option to ignore AppStore rules (I find it useful if targeting only GooglePlay)
5. `package.json` name converted `toLowerCase` since only lowercased package names are valid

Yeah... seems like prettier reformatted some lines I didn't touch. 😅