### PR TITLE
Pin colors v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/junedomingo/react-native-rename#readme",
   "dependencies": {
     "cheerio": "^0.22.0",
-    "colors": "^1.1.2",
+    "colors": "1.4.0",
     "commander": "^2.9.0",
     "globby": "^11.0.1",
     "node-replace": "^0.3.3",


### PR DESCRIPTION
Pin colors.js v1.4.0 to work around https://github.com/Marak/colors.js/issues/285.

This fixes #148.