### PR TITLE
Support new architecture(fabric)

### DIFF
--- a/src/config/bundleIdentifiers.js
+++ b/src/config/bundleIdentifiers.js
@@ -4,6 +4,8 @@ import globby from 'globby';
 
 export function bundleIdentifiers({ currentAppName, newName, currentBundleID, newBundleID, newBundlePath }) {
   const nS_CurrentAppName = currentAppName.replace(/\s/g, '');
+  const ns_CurrentBundleIDAsPath = currentBundleID.replace(/\./g, '/');
+  const ns_NewBundleIDAsPath = newBundleID.replace(/\./g, '/');
   const nS_NewName = newName.replace(/\s/g, '');
 
   return [
@@ -30,6 +32,14 @@ export function bundleIdentifiers({ currentAppName, newName, currentBundleID, ne
       regex: new RegExp(`(?!\\.)(.|^)${nS_CurrentAppName}`, 'g'),
       replacement: `$1${nS_NewName}`,
       paths: [`${newBundlePath}/MainActivity.java`],
+    },
+    {
+      regex: `L${ns_CurrentBundleIDAsPath}/newarchitecture`,
+      replacement: `L${ns_NewBundleIDAsPath}/newarchitecture`,
+      paths: [
+        'android/app/src/main/jni/MainApplicationTurboModuleManagerDelegate.h',
+        'android/app/src/main/jni/MainComponentsRegistry.h',
+      ],
     },
   ];
 }


### PR DESCRIPTION
# Description

Now update jni native code contents.

Android app crash on start up when rename and run with new architecture,
because wrong path in new architecture's native code(jni) after run react-native-rename.
(it's dependent on java package path)

This PR will resolve #162 issue.

## Changes

- now update jni native code contents
  - android/app/src/main/jni/MainApplicationTurboModuleManagerDelegate.h
  - android/app/src/main/jni/MainComponentsRegistry.h

## How to test

Rename app and build with new architecture, should app starts successfully.

- Demo: https://github.com/leegeunhyeok/react-native-rename-demo

```bash
# create react native project
npx react-native init test

# set newArchEnabled to true on gradle.properties

# clone
git@github.com:leegeunhyeok/react-native-rename.git && cd react-native-rename
git checkout feat/support-newarchitecture
npm install && npm run build
npm install -g . 

# move to test project's root directory
react-native-rename "Rename" -b com.test.rename

# build and run
npm run android
# or 
yarn android
```

## Screenshots

(rename)
<img width="1067" alt="Screen Shot 2022-11-09 at 6 11 53 PM" src="https://user-images.githubusercontent.com/26512984/200792688-1273158f-e5c2-407f-baef-c4323434df26.png">

(changes)
<img width="807" alt="Screen Shot 2022-11-09 at 6 13 30 PM" src="https://user-images.githubusercontent.com/26512984/200792825-1a10c73c-c2e9-488d-aab3-cb5690843d12.png">
<img width="807" alt="Screen Shot 2022-11-09 at 6 13 15 PM" src="https://user-images.githubusercontent.com/26512984/200792859-854d31e1-d74d-49a1-bdd0-5f0d8a6f82f6.png">


## Contexts

refs #162