### PR TITLE
Fixed some bugs found

### DIFF
--- a/src/paths.js
+++ b/src/paths.js
@@ -104,6 +104,7 @@ export const getIosUpdateFilesContentOptions = ({
         new RegExp(`INFOPLIST_FILE = ${cleanNewPathContentStr}/Info.plist;`, 'g'),
         new RegExp(`PRODUCT_NAME = "${currentName}";`, 'gi'),
         new RegExp(`PRODUCT_NAME = ${cleanNewPathContentStr};`, 'gi'),
+        new RegExp(`${currentPathContentStr}Release.entitlements`, 'gi'),
       ],
       to: [
         `INFOPLIST_KEY_CFBundleDisplayName = "${newName}"`,
@@ -128,6 +129,7 @@ export const getIosUpdateFilesContentOptions = ({
         `INFOPLIST_FILE = "${cleanNewPathContentStr}/Info.plist";`,
         `PRODUCT_NAME = "${cleanNewPathContentStr}";`,
         `PRODUCT_NAME = "${cleanNewPathContentStr}";`,
+        `${cleanNewPathContentStr}Release.entitlements`,
       ],
     },
     {

--- a/src/paths.js
+++ b/src/paths.js
@@ -186,17 +186,18 @@ export const getAndroidUpdateFilesContentOptions = ({
   newBundleIDAsPath,
 }) => {
   const newModulesName = cleanString(newName).toLowerCase();
+  const newNameStr = cleanString(newName);
 
   return [
     {
       files: 'android/settings.gradle',
       from: [/rootProject.name = "(.*)"/g, /rootProject.name = '(.*)'/g],
-      to: `rootProject.name = '${newName}'`,
+      to: `rootProject.name = '${newNameStr}'`,
     },
     {
       files: [`android/app/src/main/java/${newBundleIDAsPath}/MainActivity.java`],
       from: [`"${currentName}"`],
-      to: `"${newName}"`,
+      to: `"${newNameStr}"`,
     },
     {
       files: 'android/.idea/.name',

--- a/src/paths.js
+++ b/src/paths.js
@@ -55,7 +55,7 @@ export const getIosUpdateFilesContentOptions = ({
       to: [`${cleanNewPathContentStr}`, `${cleanNewPathContentStr}Tests`],
     },
     {
-      files: ['ios/*/AppDelegate.mm', 'ios/*/AppDelegate.m'],
+      files: ['ios/*/AppDelegate.m', 'ios/*/AppDelegate.m'],
       from: [new RegExp(`@"${currentName}"`, 'g')],
       to: `@"${newName}"`,
     },

--- a/src/paths.js
+++ b/src/paths.js
@@ -293,6 +293,7 @@ export const getOtherUpdateFilesContentOptions = ({
   newIosBundleID,
 }) => {
   const cleanNewPathContentStr = newPathContentStr.replace(/\s/g, '').toLowerCase();
+  const newNameStr = cleanString(newName);
 
   return [
     {
@@ -307,22 +308,26 @@ export const getOtherUpdateFilesContentOptions = ({
     },
     {
       files: 'app.json',
+      from: [new RegExp(`"name": "${appJsonName}"`, 'gi')],
+      to: `"name": "${newNameStr}"`,
+    },
+    {
+      files: 'app.json',
+      from: [new RegExp(`"displayName": "${appJsonDisplayName}"`, 'gi')],
+      to: `"displayName": "${newName}"`,
+    },
+    {
+      files: 'app.json',
       from: [
-        new RegExp(`${appJsonName}`, 'gi'),
-        new RegExp(`${appJsonDisplayName}`, 'gi'),
         /\"scheme\"\: \"(.*)\"/,
         /\"package\"\: \"(.*)\"/,
         /\"bundleIdentifier\"\: \"(.*)\"/,
-        /\"name\"\: \"(.*)\"/,
         /\"slug\"\: \"(.*)\"/,
       ],
       to: [
-        newName,
-        newName,
         `"scheme": "${cleanNewPathContentStr}"`,
         `"package": "${newAndroidBundleID}"`,
         `"bundleIdentifier": "${newIosBundleID}"`,
-        `"name": "${newName}"`,
         `"slug": "${newName}"`,
       ],
     },


### PR DESCRIPTION
## Resume

First I would like to thank @junedomingo for maintaining this repository!

I've been using react-native-rename for a little over a year, recently upgraded from v2.9.0 to v3.2.7. I noticed that there was a refactoring that greatly improved the organization and understanding of the code, but I noticed some problems when thoroughly testing this new version:

The command used to test was:

```shell
react-native-rename "Travel App" -b com.test.travelapp --skipGitStatusCheck
```

the original project name is <b>"Original App"</b> ( com.test.original )

## Bugs ( Fixed )

### Ios

- Description: Name is not changing

- path: `/TravelApp/iOS/AppDelegate.m`

- result: 

![Alt text](https://i.imgur.com/xDwgsWA.png "code")

- expected:

```swift
moduleName:@"TravelApp"
```

<br></br>

- Description: Entitlements name is not changing

- path: `/TravelApp/iOS/TravelApp.xcodeproj/project.pbxproj`

- result: 

![Alt text](https://i.imgur.com/FF7mtFN.png "code")

- expected:

```swift
TravelAppRelease.entitlements
```

<br></br>

- Description: CODE_SIGN_ENTITLEMENTS is not changing

- path: `/TravelApp/iOS/TravelApp.xcodeproj/project.pbxproj`

- result: 

![Alt text](https://i.imgur.com/FHEiQGr.png "code")

- expected:

```swift
TravelApp/TravelAppRelease.entitlements;
```

<br></br>

- Description: "name" Should not contain space

- path: `/TravelApp/app.json`

- result: 

![Alt text](https://i.imgur.com/Ur46afl.png "code")

- expected:

```json
{
  "name": "TravelApp",
  "displayName": "Travel App"
}
```

<br></br>

### Android


- Description: Main Component Name should not contain space

- path: `/TravelApp/android/app/src/main/java/com/test/travelapp/MainActivity.java`

- result: 

![Alt text](https://i.imgur.com/lh7ItFb.png "code")

- expected:

```java
return "TravelApp";
```

<br></br>

- Description: Rootproject should not contain space

- path: `/TravelApp/android/settings.gradle`

- result: 

![Alt text](https://i.imgur.com/w9wwDon.png "code")

- expected:

```java
rootProject.name = 'TravelApp'
```

<br></br>

### Final considerations

Some of these bugs were preventing android application build and errors in xcode on ios.

After the corrections I ran several exhaustive tests and now everything looks good.

I hope my contribution helps those who are experiencing problems. See you later 🎉