### PR TITLE
Parse app/build.gradle additionaly to find packageId

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -160,21 +160,21 @@ export const getAndroidCurrentBundleID = () => {
   const element = getElementFromXml({ filepath, selector });
 
   // parse AndroidManifest.xml
-  const packageFromManifest = element.attr('package');
-  if (packageFromManifest) {
-    return packageFromManifest;
+  const bundleIDFromManifest = element.attr('package');
+  if (bundleIDFromManifest) {
+    return bundleIDFromManifest;
   }
 
   // parse android/app/build.gradle
   const gradleFile = path.join(APP_PATH, 'android', 'app', 'build.gradle');
   const gradleFileContent = fs.readFileSync(gradleFile, 'utf8');
-  const packageFromGradle = gradleFileContent.match(/applicationId\s+['"](.+)['"]/)[1];
+  const bundleIDFromGradle = gradleFileContent.match(/applicationId\s+['"](.+)['"]/)[1];
 
-  if (packageFromGradle) {
-    return packageFromGradle;
+  if (bundleIDFromGradle) {
+    return bundleIDFromGradle;
   }
 
-  throw new Error(`Unable to get packageId from manifest or gradle file for project ${APP_PATH}`);
+  throw new Error(`Unable to get bundleID from manifest or gradle file for project ${APP_PATH}`);
 };
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,10 +51,6 @@ export const validateCreation = () => {
   const fileExists =
     fs.existsSync(iosInfoPlistFullPath) && fs.existsSync(androidValuesStringsFullPath);
 
-  if (!fs.existsSync(iosInfoPlistFullPath)) {
-    console.log(`Unable to find iOS project files at ${iosInfoPlistFullPath}. Make sure you're in the project root.`);
-  }
-
   if (!fileExists) {
     console.log('Directory should be created using "react-native init".');
     process.exit();


### PR DESCRIPTION
In react-native template started from 0.71 `AndroidManifest.xml` doesn't contain `package` field anymore ([upgrade-helper link](https://react-native-community.github.io/upgrade-helper/?from=0.70.6&to=0.71.0)) and `react-native-rename` will fail in trying to find them.

<img width="1062" alt="Снимок экрана 2023-01-15 в 12 00 30" src="https://user-images.githubusercontent.com/9128731/212532095-39e7f914-7920-47de-bb78-a1eb31b0c0ed.png">

But instead of fail, we can additionaly parse `app/build.gradle` file to find `applicationId` field and extract it from there