### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ yarn global add react-native-rename
 ```
 With **npm**:
 ```
-$ npm install react-native-rename -g
+$ npm install --location=global react-native-rename
 ```
 
 ### Support


### PR DESCRIPTION
If I use "-g" configuration, I get "npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead." warning.

"-g" configuration is deprecated. We should use "--location=global" configuration instead of "-g".