### PR TITLE
Make git repo status check language independent

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -71,8 +71,8 @@ export const validateGitRepo = () => {
 
 export const checkGitRepoStatus = () => {
   shell.cd(APP_PATH);
-  const output = shell.exec('git status', { silent: true }).stdout;
-  const isClean = output.includes('nothing to commit, working tree clean');
+  const output = shell.exec('git status --porcelain', { silent: true }).stdout;
+  const isClean = output === '';
 
   if (!isClean) {
     console.log(


### PR DESCRIPTION
With the change proposed the status is checked without referring to the specific string content (that depends on the local language) that git status returns as output.