### PR TITLE
Adds Underscore the Android Regex

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -33,7 +33,7 @@ const PROMISE_DELAY = 200;
 const MAX_NAME_LENGTH = 30;
 const NON_LANGUAGE_ALPHANUMERIC_REGEX = /[^\p{L}\p{N}]+/gu;
 const MIN_LANGUAGE_ALPHANUMERIC_NAME_LENGTH = 4;
-const VALID_ANDROID_BUNDLE_ID_REGEX = /^[a-zA-Z]{1}[a-zA-Z0-9\.]{1,}$/;
+const VALID_ANDROID_BUNDLE_ID_REGEX = /^[a-zA-Z]{1}[a-zA-Z0-9\._]{1,}$/;
 const VALID_IOS_BUNDLE_ID_REGEX = /^[a-zA-Z]{1}[a-zA-Z0-9\.\-]{1,}$/;
 
 const pluralize = (count, noun, suffix = 'es') => `${count} ${noun}${count !== 1 ? suffix : ''}`;


### PR DESCRIPTION
Underscores are also valid, this adds them to the regex

<img width="748" alt="Screenshot 2023-06-08 at 2 54 21 PM" src="https://github.com/junedomingo/react-native-rename/assets/2659478/994238eb-bd6c-4322-ab4f-85283504d4fe">
