### PR TITLE
feat: add support for Kotlin templates

### DIFF
--- a/src/paths.js
+++ b/src/paths.js
@@ -199,6 +199,11 @@ export const getAndroidUpdateFilesContentOptions = ({
       to: `"${newName}"`,
     },
     {
+      files: [`android/app/src/main/java/${newBundleIDAsPath}/MainActivity.kt`],
+      from: [`= "${currentName}"`],
+      to: `= "${newName}"`,
+    },
+    {
       files: 'android/.idea/.name',
       from: currentName,
       to: newName,
@@ -248,6 +253,8 @@ export const getAndroidUpdateBundleIDOptions = ({
         `android/app/src/release/java/${newBundleIDAsPath}/ReactNativeFlipper.java`,
         `android/app/src/main/java/${newBundleIDAsPath}/MainActivity.java`,
         `android/app/src/main/java/${newBundleIDAsPath}/MainApplication.java`,
+        `android/app/src/main/java/${newBundleIDAsPath}/MainActivity.kt`,
+        `android/app/src/main/java/${newBundleIDAsPath}/MainApplication.kt`,
       ],
       from: new RegExp(`${currentBundleID}`, 'g'),
       to: newBundleID,


### PR DESCRIPTION
## Description
Fixes https://github.com/junedomingo/react-native-rename/issues/289

In React Native 0.73, whole Android template was migrated to Kotlin, read here for more details: https://reactnative.dev/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#kotlin-template-on-android

## Test plan

1. Create new app with `npx react-native@latest init`
2. Run `node /path/to/this/tool` "newname" --bundleId com.new.name
3. Run `yarn android`, app should correctly build and run.
