### PR TITLE
Update paths.js

### DIFF
--- a/src/paths.js
+++ b/src/paths.js
@@ -191,7 +191,7 @@ export const getAndroidUpdateFilesContentOptions = ({
     {
       files: 'android/settings.gradle',
       from: [/rootProject.name = "(.*)"/g, /rootProject.name = '(.*)'/g],
-      to: `rootProject.name = '${newName}'`,
+      to: `rootProject.name = "${newName}"`,
     },
     {
       files: [`android/app/src/main/java/${newBundleIDAsPath}/MainActivity.java`],


### PR DESCRIPTION
Inside Settings.gradle, to assign rootProject.name value's string with an acceptable special character (e.g. single quote )without escaping it (ie /'). 
`Instead of wrapping rootProject.name string value in single quote 'dhaval\'superE-Shop' with back slash to escape in between single quote in string, With this double quoted string value for rootProject.name, "dhaval'superE-Shop" can be written without backward slash)`