### PR TITLE
Fix iOS Service Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ $ npx react-native-rename "Travel App" -b "com.junedomingo.travelapp"
 | :------------------------: | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-b` or `--bundleID` [value] | Set custom bundle identifier for both ios and android eg. "com.example.app" or "com.example". |
 | `--iosBundleID` [value] | Set custom bundle identifier specifically for ios. |
+| `--iosPreviousBundleID` [value] | Provide the previous bundle identifier used on iOS. Only use whenever you encounter problems with iOS Service Extensions. |
 | `--androidBundleID` [value] | Set custom bundle identifier specifically for android. |
 | `-p` or `--pathContentStr` [value] | Path and content string that can be used in replacing folders, files and their content. Make sure it doesn't include any special characters. |
 |   `--skipGitStatusCheck`   | Skip git repo status check                                                                                                                   |

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,10 @@ program
     '-b, --bundleID [value]',
     'Set custom bundle identifier for both ios and android eg. "com.example.app" or "com.example".'
   )
+  .option(
+    '--iosPreviousBundleID [value]',
+    'Provide the previous bundle identifier in case you encounter problems with iOS Service Extensions'
+  )
   .option('--iosBundleID [value]', 'Set custom bundle identifier specifically for ios')
   .option('--androidBundleID [value]', 'Set custom bundle identifier specifically for android')
   .option(
@@ -60,6 +64,7 @@ program
     const newBundleID = options.bundleID;
     const newIosBundleID = options.iosBundleID;
     const newAndroidBundleID = options.androidBundleID;
+    const iosPreviousBundleID = options.iosPreviousBundleID;
 
     if (pathContentStr) {
       validateNewPathContentStr(pathContentStr);
@@ -90,6 +95,7 @@ program
       currentPathContentStr,
       newPathContentStr,
       newBundleID: newIosBundleID || newBundleID,
+      iosPreviousBundleID,
     });
 
     await updateIosNameInInfoPlist(newName);

--- a/src/paths.js
+++ b/src/paths.js
@@ -40,6 +40,7 @@ export const getIosUpdateFilesContentOptions = ({
   currentPathContentStr,
   newPathContentStr,
   newBundleID,
+  iosPreviousBundleID,
 }) => {
   const encodedNewName = encodeXmlEntities(newName);
   const encodedCurrentName = encodeXmlEntities(currentName);
@@ -146,7 +147,8 @@ export const getIosUpdateFilesContentOptions = ({
         }
 
         // Replace bundle ID
-        if (newBundleID) {
+        if (newBundleID && !iosPreviousBundleID) {
+
           input = input.replace(
             /PRODUCT_BUNDLE_IDENTIFIER = "(.*)"/g,
             `PRODUCT_BUNDLE_IDENTIFIER = "${newBundleID}"`
@@ -156,6 +158,15 @@ export const getIosUpdateFilesContentOptions = ({
             /PRODUCT_BUNDLE_IDENTIFIER = (.*)/g,
             `PRODUCT_BUNDLE_IDENTIFIER = "${newBundleID}";`
           );
+
+        } else
+        if (newBundleID && iosPreviousBundleID) {
+
+          input = input.replace(
+            new RegExp(iosPreviousBundleID, 'g'),
+            newBundleID
+          );
+
         }
 
         return input;

--- a/src/utils.js
+++ b/src/utils.js
@@ -331,6 +331,7 @@ export const updateIosFilesContent = async ({
   currentPathContentStr,
   newPathContentStr,
   newBundleID,
+  iosPreviousBundleID,
 }) => {
   const filesContentOptions = getIosUpdateFilesContentOptions({
     currentName,
@@ -338,6 +339,7 @@ export const updateIosFilesContent = async ({
     currentPathContentStr,
     newPathContentStr,
     newBundleID,
+    iosPreviousBundleID,
   });
   await updateFilesContent(filesContentOptions);
 };


### PR DESCRIPTION
This fix circumvents using the generic replace with the new iOS bundle identifier en instead exposes the new option `iosPreviousBundleID` to add more granular replacing of the old bundle id. This fixes services extensions which are wrongly renamed to the new bundle id.

Probably related: https://github.com/junedomingo/react-native-rename/issues/291