### PR TITLE
Rename in `withModuleName:` of AppDelegate.swift for React Native 0.79

### DIFF
--- a/src/paths.js
+++ b/src/paths.js
@@ -61,8 +61,11 @@ export const getIosUpdateFilesContentOptions = ({
     },
     {
       files: 'ios/*/AppDelegate.swift',
-      from: [new RegExp(`self.moduleName = "${currentName}"`, 'g')],
-      to: `self.moduleName = "${newName}"`,
+      from: [
+        new RegExp(`self.moduleName = "${currentName}"`, 'g'),
+        new RegExp(`withModuleName: "${currentName}"`, 'g'),
+      ],
+      to: [`self.moduleName = "${newName}"`, `withModuleName: "${newName}"`],
     },
     {
       files: [


### PR DESCRIPTION
To support the new `AppDelegate.swift` in React Native 0.79.