### PR TITLE
[codex] fix rename regressions

### DIFF
--- a/src/paths.js
+++ b/src/paths.js
@@ -302,6 +302,7 @@ export const getOtherUpdateFilesContentOptions = ({
   newName,
   currentPathContentStr,
   newPathContentStr,
+  hasAppJson,
   appJsonName,
   appJsonDisplayName,
   packageJsonName,
@@ -309,8 +310,7 @@ export const getOtherUpdateFilesContentOptions = ({
   newIosBundleID,
 }) => {
   const cleanNewPathContentStr = newPathContentStr.replace(/\s/g, '').toLowerCase();
-
-  return [
+  const options = [
     {
       files: ['index.js', 'index.ios.js', 'index.android.js'],
       from: [new RegExp(`\\b${currentName}\\b`, 'g'), new RegExp(`\\b'${currentName}'\\b`, 'g')],
@@ -321,26 +321,34 @@ export const getOtherUpdateFilesContentOptions = ({
       from: [new RegExp(`${packageJsonName}`, 'gi'), new RegExp(`${currentPathContentStr}`, 'gi')],
       to: cleanNewPathContentStr,
     },
-    {
-      files: 'app.json',
-      from: [
-        new RegExp(`${appJsonName}`, 'gi'),
-        new RegExp(`${appJsonDisplayName}`, 'gi'),
-        /\"scheme\"\: \"(.*)\"/,
-        /\"package\"\: \"(.*)\"/,
-        /\"bundleIdentifier\"\: \"(.*)\"/,
-        /\"name\"\: \"(.*)\"/,
-        /\"slug\"\: \"(.*)\"/,
-      ],
-      to: [
-        newName,
-        newName,
-        `"scheme": "${cleanNewPathContentStr}"`,
-        `"package": "${newAndroidBundleID}"`,
-        `"bundleIdentifier": "${newIosBundleID}"`,
-        `"name": "${newName}"`,
-        `"slug": "${newName}"`,
-      ],
-    },
   ];
+
+  if (hasAppJson) {
+    const appJsonFrom = [
+      appJsonName && new RegExp(`${appJsonName}`, 'gi'),
+      appJsonDisplayName && new RegExp(`${appJsonDisplayName}`, 'gi'),
+      /\"scheme\"\: \"(.*)\"/,
+      /\"package\"\: \"(.*)\"/,
+      /\"bundleIdentifier\"\: \"(.*)\"/,
+      /\"name\"\: \"(.*)\"/,
+      /\"slug\"\: \"(.*)\"/,
+    ].filter(Boolean);
+    const appJsonTo = [
+      appJsonName && newName,
+      appJsonDisplayName && newName,
+      `"scheme": "${cleanNewPathContentStr}"`,
+      `"package": "${newAndroidBundleID}"`,
+      `"bundleIdentifier": "${newIosBundleID}"`,
+      `"name": "${newName}"`,
+      `"slug": "${newName}"`,
+    ].filter(Boolean);
+
+    options.push({
+      files: 'app.json',
+      from: appJsonFrom,
+      to: appJsonTo,
+    });
+  }
+
+  return options;
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -323,7 +323,7 @@ export const renameIosFoldersAndFiles = async newPathContentStr => {
 
   await renameFoldersAndFiles({
     foldersAndFilesPaths,
-    currentPath: cleanString(currentPathContentStr),
+    currentPath: currentPathContentStr,
     newPath: cleanString(newPathContentStr),
   });
 };
@@ -454,8 +454,13 @@ export const updateAndroidFilesContentBundleID = async ({
   await updateFilesContent(filesContentOptions);
 };
 
-const getJsonContent = jsonFile => {
-  return JSON.parse(fs.readFileSync(path.join(APP_PATH, jsonFile), 'utf8'));
+const getJsonContent = (jsonFile, { optional = false } = {}) => {
+  const jsonFilePath = path.join(APP_PATH, jsonFile);
+  if (optional && !fs.existsSync(jsonFilePath)) {
+    return null;
+  }
+
+  return JSON.parse(fs.readFileSync(jsonFilePath, 'utf8'));
 };
 
 export const updateOtherFilesContent = async ({
@@ -466,7 +471,7 @@ export const updateOtherFilesContent = async ({
   newAndroidBundleID,
   newIosBundleID,
 }) => {
-  const appJsonContent = getJsonContent(appJson);
+  const appJsonContent = getJsonContent(appJson, { optional: true });
   const packageJsonContent = getJsonContent(packageJson);
 
   const filesContentOptions = getOtherUpdateFilesContentOptions({
@@ -474,6 +479,7 @@ export const updateOtherFilesContent = async ({
     newName,
     currentPathContentStr,
     newPathContentStr,
+    hasAppJson: !!appJsonContent,
     appJsonName: appJsonContent?.name,
     appJsonDisplayName: appJsonContent?.displayName,
     packageJsonName: packageJsonContent?.name,
@@ -498,7 +504,7 @@ export const cleanBuilds = () => {
 };
 
 export const showSuccessMessages = newName => {
-  const appJsonContent = getJsonContent(appJson);
+  const appJsonContent = getJsonContent(appJson, { optional: true });
   const isUsingExpo = !!appJsonContent?.expo;
 
   console.log(

--- a/tests/rename.test.js
+++ b/tests/rename.test.js
@@ -80,6 +80,49 @@ const expectAndroidBundleId = (cwd, bundleId, bundlePath = 'com/example/travelap
   expect(fs.existsSync(mainApplication)).toBe(true);
 };
 
+const renameFixturePathIfExists = (cwd, from, to) => {
+  const fromPath = path.join(cwd, from);
+  if (!fs.existsSync(fromPath)) {
+    return;
+  }
+
+  fs.renameSync(fromPath, path.join(cwd, to));
+};
+
+const replaceTextInFileIfExists = (cwd, relativePath, from, to) => {
+  const filePath = path.join(cwd, relativePath);
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  fs.writeFileSync(filePath, fs.readFileSync(filePath, 'utf8').replaceAll(from, to));
+};
+
+const renameIosProjectPath = (cwd, currentName, newName) => {
+  renameFixturePathIfExists(cwd, `ios/${currentName}`, `ios/${newName}`);
+  renameFixturePathIfExists(cwd, `ios/${currentName}.xcodeproj`, `ios/${newName}.xcodeproj`);
+  renameFixturePathIfExists(cwd, `ios/${currentName}.xcworkspace`, `ios/${newName}.xcworkspace`);
+  renameFixturePathIfExists(
+    cwd,
+    `ios/${newName}.xcodeproj/xcshareddata/xcschemes/${currentName}.xcscheme`,
+    `ios/${newName}.xcodeproj/xcshareddata/xcschemes/${newName}.xcscheme`
+  );
+  replaceTextInFileIfExists(cwd, 'ios/Podfile', currentName, newName);
+  replaceTextInFileIfExists(
+    cwd,
+    `ios/${newName}.xcworkspace/contents.xcworkspacedata`,
+    currentName,
+    newName
+  );
+  replaceTextInFileIfExists(cwd, `ios/${newName}.xcodeproj/project.pbxproj`, currentName, newName);
+  replaceTextInFileIfExists(
+    cwd,
+    `ios/${newName}.xcodeproj/xcshareddata/xcschemes/${newName}.xcscheme`,
+    currentName,
+    newName
+  );
+};
+
 describe.each(activeVersions)('rn-versions/%s', version => {
   test('changes app name', () => {
     project = createFixtureProject(version);
@@ -198,5 +241,36 @@ describe.each(activeVersions)('cli validation failures/%s', version => {
 
     expect(result.status).toBe(1);
     expect(result.stdout).toContain('pathContentString');
+  });
+});
+
+describe('issue regressions', () => {
+  test('renames ios project paths that contain underscores', () => {
+    project = createFixtureProject('0.77.1');
+    renameIosProjectPath(project.cwd, 'AwesomeProject', 'Awesome_Project');
+
+    runRename(project.cwd, ['Travel App', '--skipGitStatusCheck']);
+
+    expectCommonRename(project.cwd, '0.77.1');
+    expect(fs.existsSync(path.join(project.cwd, 'ios/TravelApp'))).toBe(true);
+    expect(fs.existsSync(path.join(project.cwd, 'ios/TravelApp.xcodeproj'))).toBe(true);
+    expect(fs.existsSync(path.join(project.cwd, 'ios/TravelApp.xcworkspace'))).toBe(true);
+    expect(readFixtureFile(project.cwd, 'ios/Podfile')).not.toContain('Awesome_Project');
+    expect(readFixtureFile(project.cwd, 'ios/TravelApp.xcodeproj/project.pbxproj')).not.toContain(
+      'Awesome_Project'
+    );
+  });
+
+  test('renames projects that do not have app.json', () => {
+    project = createFixtureProject('0.85.3');
+    fs.rmSync(path.join(project.cwd, 'app.json'));
+
+    runRename(project.cwd, ['Travel App', '--skipGitStatusCheck']);
+
+    expect(fs.existsSync(path.join(project.cwd, 'app.json'))).toBe(false);
+    expect(fs.existsSync(path.join(project.cwd, 'ios/TravelApp.xcodeproj'))).toBe(true);
+    expect(readFixtureFile(project.cwd, 'android/settings.gradle')).toContain(
+      'rootProject.name = "Travel App"'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Fix iOS project path renames when the existing project name contains underscores.
- Let rename runs continue when app.json is absent, while skipping app.json-specific replacements.
- Add regression coverage for underscore iOS projects and missing app.json projects.

## Root Cause
- iOS folder renames matched against `cleanString(currentPathContentStr)`, so paths like `Awesome_Project` never matched the actual filesystem path.
- `app.json` was read unconditionally by metadata updates and success messaging.

## Test Plan
- `npm run lint`
- `npm test`