### PR TITLE
[codex] update RN 0.77 fixture deps

### DIFF
--- a/tests/rn-versions/0.77.1/package-lock.json
+++ b/tests/rn-versions/0.77.1/package-lock.json
@@ -9866,9 +9866,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -12036,9 +12036,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"


### PR DESCRIPTION
## Summary
- Update the RN 0.77.1 fixture lockfile for `node-forge` 1.4.0 and `tmp` 0.2.7.
- Keep the already-merged Babel fixture update from PR #307 intact.
- Supersedes the conflicting Dependabot PRs #308 and #309, which both touched the same lockfile base.

## Root Cause
- PR #307 advanced `tests/rn-versions/0.77.1/package-lock.json`, so GitHub could no longer cleanly create merge commits for #308 and #309.

## Verification
- `npm run lint`
- `npm test`
- `npm audit --json` in `tests/rn-versions/0.77.1` no longer reports `node-forge` or `tmp` advisories.