### PR TITLE
[codex] fix stale iOS pods after rename

### DIFF
--- a/src/paths.js
+++ b/src/paths.js
@@ -10,6 +10,7 @@ export const appJson = 'app.json';
 export const packageJson = 'package.json';
 export const buildPaths = [
   'ios/build/*',
+  'ios/Pods',
   'android/.gradle/*',
   'android/app/build/*',
   'android/build/*',

--- a/src/utils.js
+++ b/src/utils.js
@@ -491,6 +491,13 @@ export const updateOtherFilesContent = async ({
 };
 
 export const cleanBuilds = () => {
+  buildPaths.forEach(buildPath => {
+    const fullPath = path.join(APP_PATH, buildPath);
+    if (fs.existsSync(fullPath)) {
+      fs.rmSync(fullPath, { recursive: true, force: true });
+    }
+  });
+
   const pathsToRemove = globbySync(
     buildPaths.map(buildPath => normalizePath(path.join(APP_PATH, buildPath))),
     { onlyFiles: false }

--- a/tests/rename.test.js
+++ b/tests/rename.test.js
@@ -273,4 +273,14 @@ describe('issue regressions', () => {
       'rootProject.name = "Travel App"'
     );
   });
+
+  test('removes stale CocoaPods installation artifacts after ios rename', () => {
+    project = createFixtureProject('0.77.1');
+
+    runRename(project.cwd, ['Travel App', '--skipGitStatusCheck']);
+
+    expect(fs.existsSync(path.join(project.cwd, 'ios/Pods'))).toBe(false);
+    expect(fs.existsSync(path.join(project.cwd, 'ios/TravelApp.xcodeproj'))).toBe(true);
+    expect(readFixtureFile(project.cwd, 'ios/Podfile')).toContain("target 'TravelApp' do");
+  });
 });


### PR DESCRIPTION
## Summary
- Remove stale `ios/Pods` CocoaPods installation artifacts during rename cleanup.
- Preserve `Podfile.lock` so existing pod version pins remain intact for the next install.
- Add regression coverage for renamed iOS projects with existing CocoaPods artifacts.

## Root Cause
- The rename flow updated the Podfile and iOS project files, but left the previous CocoaPods installation under `ios/Pods`. That stale generated project can interfere with the next `npx react-native run-ios` auto pod-install step after rename.

## Fixes
- Fixes #303.
- This may also reduce the duplicate `.xcodeproj` confusion reported in #291 by removing `ios/Pods/Pods.xcodeproj` after rename.

## Test Plan
- `npm test -- --runInBand --testNamePattern="removes stale CocoaPods installation artifacts"`
- `npm test -- --runInBand --testNamePattern="issue regressions"`
- `npm run lint`
- `npm test`